### PR TITLE
Update 30-wordpress

### DIFF
--- a/install/assets/functions/30-wordpress
+++ b/install/assets/functions/30-wordpress
@@ -8,11 +8,11 @@ bootstrap_filesystem() {
 configure_nginx() {
     ### Perform Nginx reverse proxy modifications
     if var_true "${ENABLE_HTTPS_REVERSE_PROXY}" ; then
-        sed -i "s|fastcgi_param  HTTPS '.*';|fastcgi_param  HTTPS 'on';|g" /etc/nginx/fastcgi_params
+        sed -i "s|^fastcgi_param  HTTPS .*$|fastcgi_param  HTTPS 'on';|g" /etc/nginx/fastcgi_params
         PROTOCOL="https://"
     else
         print_warn "Disabling Nginx Reverse Proxy HTTPS Termination Support"
-        sed -i "s|fastcgi_param  HTTPS '.*';|fastcgi_param  HTTPS 'off';|g" /etc/nginx/fastcgi_params
+        sed -i "s|^fastcgi_param  HTTPS .*$|fastcgi_param  HTTPS 'off';|g" /etc/nginx/fastcgi_params
         PROTOCOL="http://"
     fi
 }


### PR DESCRIPTION
Fix an issue with different default values of HTTPS options in fastcgi_params. It didn't change when you try to change ENABLE_HTTPS_REVERSE_PROXY variable.